### PR TITLE
Add PDF streaming and basic viewer

### DIFF
--- a/JustViewer/Controllers/PdfController.cs
+++ b/JustViewer/Controllers/PdfController.cs
@@ -1,0 +1,33 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace JustViewer.Controllers;
+
+public class PdfController : Controller
+{
+    private readonly IWebHostEnvironment _env;
+
+    public PdfController(IWebHostEnvironment env)
+    {
+        _env = env;
+    }
+
+    [HttpGet("Pdf/View/{fileName}")]
+    public IActionResult View(string fileName)
+    {
+        ViewData["FileName"] = fileName;
+        return View();
+    }
+
+    [HttpGet("Pdf/Stream/{fileName}")]
+    public IActionResult Stream(string fileName)
+    {
+        var filePath = Path.Combine(_env.WebRootPath, "pdf", fileName);
+        if (!System.IO.File.Exists(filePath))
+        {
+            return NotFound();
+        }
+
+        var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+        return File(stream, "application/pdf", enableRangeProcessing: true);
+    }
+}

--- a/JustViewer/Views/Home/Index.cshtml
+++ b/JustViewer/Views/Home/Index.cshtml
@@ -1,8 +1,8 @@
-﻿@{
+@{
     ViewData["Title"] = "Home Page";
 }
 
 <div class="text-center">
     <h1 class="display-4">Welcome</h1>
-    <p>Learn about <a href="https://learn.microsoft.com/aspnet/core">building Web apps with ASP.NET Core</a>.</p>
+    <p>Open the <a asp-controller="Pdf" asp-action="View" asp-route-fileName="sample.pdf">sample PDF viewer</a>.</p>
 </div>

--- a/JustViewer/Views/Pdf/View.cshtml
+++ b/JustViewer/Views/Pdf/View.cshtml
@@ -1,0 +1,8 @@
+@{
+    ViewData["Title"] = "PDF Viewer";
+    var fileName = ViewData["FileName"] as string ?? "";
+}
+
+<div class="ratio ratio-1x1" style="height:80vh;">
+    <iframe id="pdfFrame" src="~/js/pdfjs/viewer.html?file=/Pdf/Stream/@fileName" width="100%" height="100%" style="border:none;"></iframe>
+</div>

--- a/JustViewer/wwwroot/js/pdfjs/README.txt
+++ b/JustViewer/wwwroot/js/pdfjs/README.txt
@@ -1,0 +1,2 @@
+This directory will contain the PDF.js distribution.
+Run ../../../../scripts/fetch_pdfjs.sh to download the required files.

--- a/JustViewer/wwwroot/pdf/sample.pdf
+++ b/JustViewer/wwwroot/pdf/sample.pdf
@@ -1,0 +1,57 @@
+%PDF-1.4
+1 0 obj
+<<
+/Type /Catalog
+/Pages 2 0 R
+>>
+endobj
+2 0 obj
+<<
+/Type /Pages
+/Count 1
+/Kids [3 0 R]
+>>
+endobj
+3 0 obj
+<<
+/Type /Page
+/Parent 2 0 R
+/MediaBox [0 0 612 792]
+/Contents 4 0 R
+/Resources <<
+/Font << /F1 5 0 R >>
+>>
+>>
+endobj
+4 0 obj
+<< /Length 44 >>
+stream
+BT
+/F1 24 Tf
+100 700 Td
+(Hello JustViewer) Tj
+ET
+endstream
+endobj
+5 0 obj
+<<
+/Type /Font
+/Subtype /Type1
+/BaseFont /Helvetica
+>>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000010 00000 n 
+0000000054 00000 n 
+0000000107 00000 n 
+0000000209 00000 n 
+0000000295 00000 n 
+trailer
+<< /Size 6
+/Root 1 0 R
+>>
+startxref
+344
+%%EOF

--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
 # JustViewer
+
+JustViewer is a minimal ASP.NET Core MVC application demonstrating how to stream and view large PDF files efficiently.
+
+## Requirements
+
+- .NET 9 SDK
+- Optional: `curl` (or `wget`) to download PDF.js assets
+
+## Setup
+
+1. **Fetch PDF.js** (first time only)
+
+   Run the helper script to download the PDF.js distribution into `wwwroot/js/pdfjs/`:
+
+   ```bash
+   ./scripts/fetch_pdfjs.sh
+   ```
+
+2. **Run the application**
+
+   ```bash
+   dotnet run --project JustViewer/JustViewer.csproj
+   ```
+
+3. Navigate to `https://localhost:5001` (or the printed URL) and open the sample PDF from the home page.
+
+The sample PDF is located in `wwwroot/pdf/sample.pdf`. Add your own PDF files to this folder and open them via `/Pdf/View/{fileName}`.
+
+## Notes
+
+- PDF streaming endpoint supports HTTP range requests for fast incremental loading of large files.
+- The viewer page simply embeds PDF.js' default `viewer.html` so all default controls (zoom, search, bookmarks, thumbnails, print, download) are available.

--- a/scripts/fetch_pdfjs.sh
+++ b/scripts/fetch_pdfjs.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Simple helper to download PDF.js distribution into wwwroot/js/pdfjs
+# Requires curl or wget and internet access.
+set -e
+VERSION=3.11.174
+TARGET_DIR="$(dirname "$0")/../JustViewer/wwwroot/js/pdfjs"
+mkdir -p "$TARGET_DIR"
+BASE_URL="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/$VERSION"
+
+curl -L "$BASE_URL/pdf.min.js" -o "$TARGET_DIR/pdf.min.js"
+curl -L "$BASE_URL/pdf.worker.min.js" -o "$TARGET_DIR/pdf.worker.min.js"
+curl -L "$BASE_URL/pdf_viewer.min.js" -o "$TARGET_DIR/pdf_viewer.min.js"
+curl -L "$BASE_URL/pdf_viewer.min.css" -o "$TARGET_DIR/pdf_viewer.min.css"
+# Download the viewer HTML
+curl -L "https://raw.githubusercontent.com/mozilla/pdf.js/v$VERSION/web/viewer.html" -o "$TARGET_DIR/viewer.html"


### PR DESCRIPTION
## Summary
- add `PdfController` with range streaming
- embed PDF.js viewer via new `Pdf/View` page
- add sample PDF
- add script to download PDF.js assets
- update home page and README with usage instructions

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ac17aab048320b41fbd73c782e48c