### PR TITLE
Fix PDF viewer assets fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ JustViewer is a minimal ASP.NET Core MVC application demonstrating how to stream
 
 1. **Fetch PDF.js** (first time only)
 
-   Run the helper script to download the PDF.js distribution into `wwwroot/js/pdfjs/`:
+   Run the helper script to download the PDF.js distribution (including `viewer.html` and associated scripts) into `wwwroot/js/pdfjs/`:
 
    ```bash
    ./scripts/fetch_pdfjs.sh

--- a/scripts/fetch_pdfjs.sh
+++ b/scripts/fetch_pdfjs.sh
@@ -11,5 +11,7 @@ curl -L "$BASE_URL/pdf.min.js" -o "$TARGET_DIR/pdf.min.js"
 curl -L "$BASE_URL/pdf.worker.min.js" -o "$TARGET_DIR/pdf.worker.min.js"
 curl -L "$BASE_URL/pdf_viewer.min.js" -o "$TARGET_DIR/pdf_viewer.min.js"
 curl -L "$BASE_URL/pdf_viewer.min.css" -o "$TARGET_DIR/pdf_viewer.min.css"
-# Download the viewer HTML
-curl -L "https://raw.githubusercontent.com/mozilla/pdf.js/v$VERSION/web/viewer.html" -o "$TARGET_DIR/viewer.html"
+# Fetch viewer assets from the CDN distribution as well
+curl -L "$BASE_URL/web/viewer.html" -o "$TARGET_DIR/viewer.html"
+curl -L "$BASE_URL/web/viewer.js" -o "$TARGET_DIR/viewer.js"
+curl -L "$BASE_URL/web/viewer.css" -o "$TARGET_DIR/viewer.css"


### PR DESCRIPTION
## Summary
- download the full PDF.js viewer bundle from the CDN
- clarify README to mention viewer assets

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ac42992688320bd3082f48985400a