### PR TITLE
Custom viewer wrapper

### DIFF
--- a/JustViewer/Views/Pdf/View.cshtml
+++ b/JustViewer/Views/Pdf/View.cshtml
@@ -2,7 +2,98 @@
     ViewData["Title"] = "PDF Viewer";
     var fileName = ViewData["FileName"] as string ?? "";
 }
-
-<div class="ratio ratio-1x1" style="height:80vh;">
-    <iframe id="pdfFrame" src="~/js/pdfjs/viewer.html?file=/Pdf/Stream/@fileName" width="100%" height="100%" style="border:none;"></iframe>
+<link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
+<style>
+    body {
+        background: linear-gradient(135deg,#667eea 0%,#764ba2 100%);
+    }
+    .viewer-wrapper {
+        max-width: 1200px;
+        margin: 2rem auto;
+        background: #fff;
+        border-radius: 12px;
+        box-shadow: 0 10px 40px rgba(0,0,0,0.15);
+        overflow: hidden;
+    }
+    .viewer-header {
+        display:flex;
+        justify-content: space-between;
+        align-items:center;
+        padding:1rem 1.5rem;
+        background:#2c3e50;
+        color:#fff;
+    }
+    .viewer-actions a,
+    .viewer-actions button {
+        margin-left:0.5rem;
+    }
+    .toolbar {
+        background:#f8f9fa;
+        padding:0.5rem 1rem;
+        display:flex;
+        justify-content:space-between;
+        align-items:center;
+    }
+    .toolbar button {
+        margin-right:0.25rem;
+    }
+    .pdf-frame {
+        width:100%;
+        height:80vh;
+        border:none;
+    }
+</style>
+<div class="viewer-wrapper">
+    <div class="viewer-header">
+        <div>
+            <i class="fas fa-file-pdf"></i> <span>@fileName</span>
+        </div>
+        <div class="viewer-actions">
+            <a class="btn btn-sm btn-light" download href="/Pdf/Stream/@fileName"><i class="fas fa-download"></i> Download</a>
+            <button class="btn btn-sm btn-light" onclick="printPDF()"><i class="fas fa-print"></i> Print</button>
+            <button class="btn btn-sm btn-light" onclick="toggleFullscreen()"><i class="fas fa-expand"></i></button>
+        </div>
+    </div>
+    <div class="toolbar">
+        <div>
+            <button class="btn btn-sm btn-outline-secondary" onclick="zoomOut()"><i class="fas fa-minus"></i></button>
+            <span id="zoomDisplay" class="mx-1">100%</span>
+            <button class="btn btn-sm btn-outline-secondary" onclick="zoomIn()"><i class="fas fa-plus"></i></button>
+        </div>
+        <div>
+            <button class="btn btn-sm btn-outline-secondary" onclick="prevPage()"><i class="fas fa-chevron-left"></i></button>
+            <span id="pageDisplay" class="mx-1">Page 1</span>
+            <button class="btn btn-sm btn-outline-secondary" onclick="nextPage()"><i class="fas fa-chevron-right"></i></button>
+        </div>
+    </div>
+    <iframe id="pdfFrame" class="pdf-frame" src="~/js/pdfjs/viewer.html?file=/Pdf/Stream/@fileName"></iframe>
 </div>
+
+@section Scripts {
+<script>
+    const frame = document.getElementById('pdfFrame');
+    function withViewer(fn) {
+        if (!frame.contentWindow || !frame.contentWindow.PDFViewerApplication) return;
+        return fn(frame.contentWindow.PDFViewerApplication);
+    }
+    function updateStatus(app) {
+        document.getElementById('zoomDisplay').textContent = Math.round(app.pdfViewer.currentScale * 100) + '%';
+        document.getElementById('pageDisplay').textContent = `Page ${app.page} of ${app.pagesCount}`;
+    }
+    frame.addEventListener('load', () => {
+        const app = frame.contentWindow.PDFViewerApplication;
+        if (app.initialized) updateStatus(app);
+        else frame.contentWindow.addEventListener('webviewerloaded', () => updateStatus(frame.contentWindow.PDFViewerApplication));
+    });
+    function zoomIn(){ withViewer(app => { app.zoomIn(); updateStatus(app); }); }
+    function zoomOut(){ withViewer(app => { app.zoomOut(); updateStatus(app); }); }
+    function nextPage(){ withViewer(app => { app.page = Math.min(app.page + 1, app.pagesCount); updateStatus(app); }); }
+    function prevPage(){ withViewer(app => { app.page = Math.max(app.page - 1, 1); updateStatus(app); }); }
+    function printPDF(){ withViewer(app => app.print()); }
+    function toggleFullscreen(){
+        const el = document.documentElement;
+        if(!document.fullscreenElement) el.requestFullscreen();
+        else document.exitFullscreen();
+    }
+</script>
+}


### PR DESCRIPTION
## Summary
- replace the simple iframe page with a custom layout inspired by the provided design
- expose zoom and page controls that call the embedded PDF.js viewer API

## Testing
- `dotnet build JustViewer/JustViewer.csproj -warnaserror` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ac8d9ff5c8320914f08f4f50a54d4