### PR TITLE
Fix PDF viewer page

### DIFF
--- a/JustViewer/Views/Pdf/View.cshtml
+++ b/JustViewer/Views/Pdf/View.cshtml
@@ -19,7 +19,7 @@
 
     <iframe id="pdfFrame"
             class="pdf-frame"
-            src="/js/pdfjs/web/viewer.html?file=/Pdf/Stream/@Uri.EscapeDataString(fileName)"
+            src="/js/pdfjs/viewer.html?file=/Pdf/Stream/@Uri.EscapeDataString(fileName)"
             style="display: none;"
             onload="hideLoading()"
             onerror="showError()">


### PR DESCRIPTION
## Summary
- fix missing PDF.js assets path in the viewer page

## Testing
- `dotnet build JustViewer/JustViewer.csproj -v q` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bb546af008320af85a3a89306dde2